### PR TITLE
Update to use latest mex-based matlab/octave HPIPM interface

### DIFF
--- a/Matlab/env.sh
+++ b/Matlab/env.sh
@@ -1,0 +1,50 @@
+#! /usr/bin/bash
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]
+then
+	echo "Script is being sourced"
+else
+	echo "ERROR: Script is a subshell"
+	echo "To affect your current shell enviroment source this script with:"
+	echo "source env.sh"
+	exit
+fi
+
+# check that this file is run
+export ENV_RUN=true
+
+# if hpipm folder not specified assume parent of this folder
+HPIPM_MAIN_FOLDER=${HPIPM_MAIN_FOLDER:-"$(pwd)/../../hpipm"}
+export HPIPM_MAIN_FOLDER
+echo
+echo "HPIPM_MAIN_FOLDER=$HPIPM_MAIN_FOLDER"
+
+# if blasfeo folder not specified assume alongside the parent of this folder
+BLASFEO_MAIN_FOLDER=${BLASFEO_MAIN_FOLDER:-"$(pwd)/../../blasfeo"}
+export BLASFEO_MAIN_FOLDER
+echo
+echo "BLASFEO_MAIN_FOLDER=$BLASFEO_MAIN_FOLDER"
+
+# export matlab_octave_mex folder
+# MATLAB case
+export MATLABPATH=$MATLABPATH:$HPIPM_MAIN_FOLDER/interfaces/matlab_octave/
+echo
+echo "MATLABPATH=$MATLABPATH"
+# Octave case
+export OCTAVE_PATH=$OCTAVE_PATH:$HPIPM_MAIN_FOLDER/interfaces/matlab_octave/
+echo
+echo "OCTAVE_PATH=$OCTAVE_PATH"
+
+#export HPIPM_MEX_FLAGS="GCC=/usr/bin/gcc-4.9"
+
+# export LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HPIPM_MAIN_FOLDER/lib:$BLASFEO_MAIN_FOLDER/lib
+echo
+echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+
+# folder containig the data file
+DATA_FOLDER=${DATA_FOLDER:-"$(pwd)"}
+export DATA_FOLDER
+echo
+echo "DATA_FOLDER=$DATA_FOLDER"
+

--- a/Matlab/env.sh
+++ b/Matlab/env.sh
@@ -13,7 +13,7 @@ fi
 # check that this file is run
 export ENV_RUN=true
 
-# if hpipm folder not specified assume parent of this folder
+# if hpipm folder not specified assume alongside the parent of this folder
 HPIPM_MAIN_FOLDER=${HPIPM_MAIN_FOLDER:-"$(pwd)/../../hpipm"}
 export HPIPM_MAIN_FOLDER
 echo
@@ -41,10 +41,4 @@ echo "OCTAVE_PATH=$OCTAVE_PATH"
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HPIPM_MAIN_FOLDER/lib:$BLASFEO_MAIN_FOLDER/lib
 echo
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
-
-# folder containig the data file
-DATA_FOLDER=${DATA_FOLDER:-"$(pwd)"}
-export DATA_FOLDER
-echo
-echo "DATA_FOLDER=$DATA_FOLDER"
 

--- a/Matlab/getMPCmatrices.m
+++ b/Matlab/getMPCmatrices.m
@@ -69,16 +69,16 @@ stage(i).fk = costScale*generatef(traj,MPC_vars,ModelParams,Xk,i);
 % bounds
 [stage(i).lb, stage(i).ub] = getBounds(MPC_vars,ModelParams);
 %% Call solver interface
-if MPC_vars.interface == "Yalmip"
+if strcmp(MPC_vars.interface, 'Yalmip')
     % yalmip based interface (very slow)
     [X,U,dU,info] = YalmipInterface(stage,MPC_vars,ModelParams);
-elseif MPC_vars.interface == "CVX"
+elseif strcmp(MPC_vars.interface, 'CVX')
     % CVX based interface (slow)
     [X,U,dU,info] = CVXInterface(stage,MPC_vars,ModelParams);
-elseif MPC_vars.interface == "hpipm"
+elseif strcmp(MPC_vars.interface, 'hpipm')
     % hpipm interface (prefered)
     [X,U,dU,info] = hpipmInterface(stage,MPC_vars,ModelParams);
-elseif MPC_vars.interface == "quadprog"
+elseif strcmp(MPC_vars.interface, 'quadprog')
     % quadprog interface (replace quadprog with a better solver if possible)
     [X,U,dU,info] = QuadProgInterface(stage,MPC_vars,ModelParams);
 else

--- a/Matlab/getNewBorders.m
+++ b/Matlab/getNewBorders.m
@@ -935,11 +935,12 @@ function [in] = inpoly(points,vertices)
 
 % determinse whether a point is inside the polytop given by the vertices
 n = length(points);
-CorrectSum = sum(convhull(vertices));
+CorrectSum = sum(convhull(vertices(:,1),vertices(:,2)));
 in = false(n,1);
 for i = 1:n
     
-    if sum(convhull([vertices;points(i,:)])) == CorrectSum
+	tmp_vertices = [vertices;points(i,:)];
+    if sum(convhull(tmp_vertices(:,1),tmp_vertices(:,2))) == CorrectSum
         in(i) = 1;
     else
         in(i) = 0;

--- a/Matlab/hpipmInterface.m
+++ b/Matlab/hpipmInterface.m
@@ -14,88 +14,120 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 function [ X,U,dU,info ] = hpipmInterface(stage,MPC_vars,ModelParams)
+
+
+% check that env.sh has been run
+env_run = getenv('ENV_RUN');
+if (~strcmp(env_run, 'true'))
+	disp('ERROR: env.sh has not been sourced! Before using the HPIPM solver, run in the shell:');
+	disp('source env.sh');
+	disp('and then launch matlab or octave from the same shell.');
+	disp('(tested on linux, untested on windows as of now).');
+	return;
+end
+
+
 nx = ModelParams.nx;
 nu = ModelParams.nu;
 qpTotal = tic;
 
-import hpipm_matlab.*
+%import hpipm_matlab.*
 
 % dims
 N = MPC_vars.N;
 
 dims = hpipm_ocp_qp_dim(N);
 
-dims.set('nx',(nx+nu)*ones(1,N+1));
-dims.set('nu',nu*ones(1,N));
+dims.set('nx', (nx+nu), 0, N);
+dims.set('nu', nu, 0, N-1);
 
-dims.set('nbx',(nx+nu)*ones(1,N+1));
-dims.set('nbu',nu*ones(1,N));
+dims.set('nbx', (nx+nu), 0, N);
+dims.set('nbu', nu, 0, N-1);
 
-dims.set('ng',[0,1*ones(1,N)]);
+dims.set('ng', 0, 0);
+dims.set('ng', 1, 1, N);
+
+%dims.print_C_struct();
+
 
 % qp
 qp = hpipm_ocp_qp(dims);
 %% Equility Constraints
 x0 = blkdiag(MPC_vars.Tx,MPC_vars.Tu)*[stage(1).x0;stage(1).u0];
 for i = 0:N-1
-   qp.set('A',stage(i+1).Ak,i); 
-   qp.set('B',stage(i+1).Bk,i); 
-   qp.set('b',stage(i+1).gk,i); 
+   qp.set('A', stage(i+1).Ak, i); 
+   qp.set('B', stage(i+1).Bk, i); 
+   qp.set('b', stage(i+1).gk, i); 
 end
 
 %% Cost
 for i = 0:N
-    qp.set('Q',stage(i+1).Qk,i);
-    qp.set('q',stage(i+1).fk,i);
+    qp.set('Q', stage(i+1).Qk, i);
+    qp.set('q', stage(i+1).fk, i);
     if i<N
-        qp.set('R',stage(i+1).Rk,i); 
+        qp.set('R', stage(i+1).Rk, i); 
     end
 end
 %% Constraints
 for i = 1:N
-    qp.set('C',stage(i+1).Ck,i);
-    qp.set('lg',stage(i+1).lg,i); 
-    qp.set('ug',stage(i+1).ug,i); 
+    qp.set('C', stage(i+1).Ck, i);
+    qp.set('lg', stage(i+1).lg, i); 
+    qp.set('ug', stage(i+1).ug, i); 
 end
 %% Bounds
+%qp.print_C_struct();
 for i = 0:N
-    qp.set('Jx',eye(nx+nu),i)
+    qp.set('Jbx', eye(nx+nu), i)
     if i == 0
-        qp.set('lx',x0,0)
-        qp.set('ux',x0,0)
+        qp.set('lbx', x0, 0)
+        qp.set('ubx', x0, 0)
     else
-        qp.set('lx',stage(i+1).lb(1:nx+nu),i)
-        qp.set('ux',stage(i+1).ub(1:nx+nu),i)
+        qp.set('lbx', stage(i+1).lb(1:nx+nu), i)
+        qp.set('ubx', stage(i+1).ub(1:nx+nu), i)
     end
     
     if i<N
-        qp.set('Ju',eye(nu),i)
-        qp.set('lu',stage(i+1).lb(nx+nu+1:end),i)
-        qp.set('uu',stage(i+1).ub(nx+nu+1:end),i)
+        qp.set('Jbu', eye(nu), i)
+        qp.set('lbu', stage(i+1).lb(nx+nu+1:nx+nu+nu), i)
+        qp.set('ubu', stage(i+1).ub(nx+nu+1:nx+nu+nu), i)
     end
 end
     
+%qp.print_C_struct();
+
+
 %%
 qp_sol = hpipm_ocp_qp_sol(dims);
 
-% set up solver arg
-arg = hpipm_ocp_qp_solver_arg(dims);
 
-arg.set_mu0(1e0);
-arg.set_iter_max(200);
-arg.set_tol_stat(1e-6);
-arg.set_tol_eq(1e-6);
-arg.set_tol_ineq(1e-6);
-arg.set_tol_comp(1e-5);
-arg.set_reg_prim(1e-12);
+%% set up solver arg
+%mode = 'speed_abs';
+mode = 'speed';
+%mode = 'balance';
+%mode = 'robust';
+% create and set default arg based on mode
+arg = hpipm_ocp_qp_solver_arg(dims, mode);
+
+arg.set('mu0', 1e0);
+arg.set('iter_max', 200);
+arg.set('tol_stat', 1e-6);
+arg.set('tol_eq', 1e-6);
+arg.set('tol_ineq', 1e-6);
+arg.set('tol_comp', 1e-5);
+arg.set('reg_prim', 1e-12);
+
 
 % set up solver
 solver = hpipm_ocp_qp_solver(dims, arg);
 
+
 % solve qp
 qptime = tic;
-return_flag = solver.solve(qp, qp_sol);
+solver.solve(qp, qp_sol);
 tmp_time = toc(qptime);
+
+return_flag = solver.get('status');
+
 fprintf('solve time %e\n', tmp_time);
 
 fprintf('HPIPM returned with flag %d ', return_flag);
@@ -112,10 +144,10 @@ end
 u_opt = zeros(nu,N);
 x_opt = zeros(nx+nu,N);
 for i=0:N-1
-    u_opt(:,i+1) = qp_sol.get_u(i);
+    u_opt(:,i+1) = qp_sol.get('u', i);
 end
 for i=0:N
-	x_opt(:,i+1) = qp_sol.get_x(i);
+	x_opt(:,i+1) = qp_sol.get('x', i);
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 QPtime = toc(qpTotal);
@@ -131,6 +163,20 @@ else
     info.exitflag = 1;
 end
 info.QPtime = tmp_time;
+
+
+
+if is_octave()
+	% directly call destructor for octave 4.2.2 (ubuntu 18.04) + others ???
+	if strcmp(version(), '4.2.2')
+		delete(dims);
+		delete(qp);
+		delete(qp_sol);
+		delete(arg);
+		delete(solver);
+	end
+end
+
 
 
 end

--- a/Matlab/simulation.m
+++ b/Matlab/simulation.m
@@ -14,9 +14,9 @@
 clear
 close all
 clc
+
 %% add spline library
 addpath('splines');
-addpath('~/Documents/GitHub/hpipm/interfaces/matlab/hpipm_matlab')
 %% Load Parameters
 CarModel = 'ORCA';
 % CarModel = 'FullSize';
@@ -25,6 +25,7 @@ MPC_vars = getMPC_vars(CarModel);
 ModelParams=getModelParams(MPC_vars.ModelNo);
 % choose optimization interface options: 'Yalmip','CVX','hpipm','quadprog'
 MPC_vars.interface = 'hpipm';
+
 
 nx = ModelParams.nx;
 nu = ModelParams.nu;


### PR DESCRIPTION
The `hpipmInterface.m` has been updated to use the new mex-based matlab/octave HPIPM interface (the old python-based interface is now discontinued). The code is also updated to work on both matlab and octave.

The PR has been tested on linux.