### PR TITLE
Removed relative paths for JSONs

### DIFF
--- a/C++/Constraints/bounds.cpp
+++ b/C++/Constraints/bounds.cpp
@@ -18,6 +18,10 @@
 namespace mpcc{
 Bounds::Bounds()
 {
+}
+
+Bounds::Bounds(BoundsParam bounds_param) 
+{
     l_bounds_x_(0) = bounds_param.lower_state_bounds.X_l;
     l_bounds_x_(1) = bounds_param.lower_state_bounds.Y_l;
     l_bounds_x_(2) = bounds_param.lower_state_bounds.phi_l;

--- a/C++/Constraints/bounds.h
+++ b/C++/Constraints/bounds.h
@@ -23,6 +23,7 @@ namespace mpcc{
 class Bounds {
 public:
     Bounds();
+    Bounds(BoundsParam bounds_param);
 
     Bounds_x getBoundsLX() const;
     Bounds_x getBoundsUX() const;
@@ -34,6 +35,7 @@ public:
     Bounds_s getBoundsUS() const;
 
 private:
+
     Bounds_x u_bounds_x_;
     Bounds_x l_bounds_x_;
 

--- a/C++/Constraints/constraints.h
+++ b/C++/Constraints/constraints.h
@@ -37,6 +37,9 @@ struct OneDConstraint {
 
 class Constraints {
 public:
+    Constraints();
+    Constraints(Param params);
+    
     ConstrainsMatrix getConstraints(const ArcLengthSpline &track,const State &x,const Input &u) const;
 private:
     OneDConstraint getTrackConstraints(const ArcLengthSpline &track,const State &x) const;

--- a/C++/Cost/cost.h
+++ b/C++/Cost/cost.h
@@ -49,7 +49,14 @@ struct ErrorInfo{
 class Cost {
 public:
     CostMatrix getCost(const ArcLengthSpline &track, const State &x,int k) const;
+
+    //void setCosts(const CostParam &cost_param) { cost_param_ = cost_param; }
+    Cost(CostParam cost_param);
+    Cost();
+
 private:
+    CostParam cost_param_;
+
     TrackPoint getRefPoint(const ArcLengthSpline &track,const State &x) const;
     ErrorInfo  getErrorInfo(const ArcLengthSpline &track,const State &x) const;
 

--- a/C++/MPC/mpc.h
+++ b/C++/MPC/mpc.h
@@ -77,7 +77,7 @@ public:
 
     void setTrack(const Eigen::VectorXd &X, const Eigen::VectorXd &Y);
 
-    MPC(int n_sqp, int n_reset, double sqp_mixing);
+    MPC(int n_sqp, int n_reset, double sqp_mixing, Param params, CostParam cost_param, BoundsParam bounds_param);
 
 private:
     bool valid_initial_guess_;

--- a/C++/Model/integrator.cpp
+++ b/C++/Model/integrator.cpp
@@ -16,6 +16,13 @@
 
 #include "integrator.h"
 namespace mpcc{
+Integrator::Integrator(){
+}
+
+Integrator::Integrator(Param param){
+  setParam(param);
+}
+
 State Integrator::RK4(const State &x, const Input &u,const double ts) const
 {
     // 4th order Runge Kutta (RK4) implementation

--- a/C++/Model/integrator.h
+++ b/C++/Model/integrator.h
@@ -27,6 +27,15 @@ public:
     State RK4(const State &x, const Input &u,double ts) const;
     State EF(const State &x, const Input &u,double ts) const;
     State simTimeStep(const State &x, const Input &u,double ts) const;
+
+    Integrator();
+
+    Integrator(Param param);
+
+    void setParam(const Param &param) { model_.setParam(param); }
+
+    Model getModel(void) const { return model_; }
+
 private:
     const double fine_time_step_ = 0.001;
 

--- a/C++/Model/model.cpp
+++ b/C++/Model/model.cpp
@@ -19,19 +19,19 @@ namespace mpcc{
 double Model::getSlipAngleFront(const State &x) const
 {
     // compute slip angels given current state
-    return -std::atan2(x.vy+x.r*param.lf,x.vx) + x.delta;
+    return -std::atan2(x.vy+x.r*param_.lf,x.vx) + x.delta;
 }
 
 double Model::getSlipAngleRear(const State &x) const
 {
     // compute slip angels given current state
-    return -std::atan2(x.vy-x.r*param.lr,x.vx);
+    return -std::atan2(x.vy-x.r*param_.lr,x.vx);
 }
 
 TireForces Model::getForceFront(const State &x) const
 {
     const double alpha_f = getSlipAngleFront(x);
-    const double F_y = param.Df * std::sin(param.Cf * std::atan(param.Bf * alpha_f ));
+    const double F_y = param_.Df * std::sin(param_.Cf * std::atan(param_.Bf * alpha_f ));
     const double F_x = 0.0;
 
     return {F_y,F_x};
@@ -40,22 +40,22 @@ TireForces Model::getForceFront(const State &x) const
 TireForces Model::getForceRear(const State &x) const
 {
     const double alpha_r = getSlipAngleRear(x);
-    const double F_y = param.Dr * std::sin(param.Cr * std::atan(param.Br * alpha_r ));
-    const double F_x = param.Cm1*x.D - param.Cm2*x.D*x.vx;// - param.Cr0 - param.Cr2*std::pow(x.vx,2.0);
+    const double F_y = param_.Dr * std::sin(param_.Cr * std::atan(param_.Br * alpha_r ));
+    const double F_x = param_.Cm1*x.D - param_.Cm2*x.D*x.vx;// - param_.Cr0 - param_.Cr2*std::pow(x.vx,2.0);
 
     return {F_y,F_x};
 }
 
 double Model::getForceFriction(const State &x) const
 {
-    return -param.Cr0 - param.Cr2*std::pow(x.vx,2.0);
+    return -param_.Cr0 - param_.Cr2*std::pow(x.vx,2.0);
 }
 
 NormalForces Model::getForceNormal(const State &x) const
 {
     // at this point aero forces could be modeled
-    const double f_n_front = param.lr/(param.lf + param.lr)*param.m*param.g;
-    const double f_n_rear = param.lf/(param.lf + param.lr)*param.m*param.g;
+    const double f_n_front = param_.lr/(param_.lf + param_.lr)*param_.m*param_.g;
+    const double f_n_rear = param_.lf/(param_.lf + param_.lr)*param_.m*param_.g;
     return {f_n_front,f_n_rear};
 }
 
@@ -73,18 +73,18 @@ TireForcesDerivatives Model::getForceFrontDerivatives(const State &x) const
     const double dF_x_D     = 0.0;
     const double dF_x_delta = 0.0;
     // F_fy
-    const double dF_y_vx    = (param.Bf*param.Cf*param.Df*std::cos(param.Cf*std::atan(param.Bf*alpha_f)))
-                                            /(1.+std::pow(param.Bf,2)*std::pow(alpha_f,2))*((param.lf*r + vy)
-                                            /(std::pow((param.lf*r + vy),2)+std::pow(vx,2)));
-    const double dF_y_vy    = (param.Bf*param.Cf*param.Df*std::cos(param.Cf*std::atan(param.Bf*alpha_f)))
-                                            /(1.+std::pow(param.Bf,2)*std::pow(alpha_f,2))
-                                            *(-vx/(std::pow((param.lf*r + vy),2)+std::pow(vx,2)));
-    const double dF_y_r     =  (param.Bf*param.Cf*param.Df*std::cos(param.Cf*std::atan(param.Bf*alpha_f)))
-                                            /(1.+std::pow(param.Bf,2)*std::pow(alpha_f,2))*((-param.lf*vx)
-                                            /(std::pow((param.lf*r + vy),2)+std::pow(vx,2)));
+    const double dF_y_vx    = (param_.Bf*param_.Cf*param_.Df*std::cos(param_.Cf*std::atan(param_.Bf*alpha_f)))
+                                            /(1.+std::pow(param_.Bf,2)*std::pow(alpha_f,2))*((param_.lf*r + vy)
+                                            /(std::pow((param_.lf*r + vy),2)+std::pow(vx,2)));
+    const double dF_y_vy    = (param_.Bf*param_.Cf*param_.Df*std::cos(param_.Cf*std::atan(param_.Bf*alpha_f)))
+                                            /(1.+std::pow(param_.Bf,2)*std::pow(alpha_f,2))
+                                            *(-vx/(std::pow((param_.lf*r + vy),2)+std::pow(vx,2)));
+    const double dF_y_r     =  (param_.Bf*param_.Cf*param_.Df*std::cos(param_.Cf*std::atan(param_.Bf*alpha_f)))
+                                            /(1.+std::pow(param_.Bf,2)*std::pow(alpha_f,2))*((-param_.lf*vx)
+                                            /(std::pow((param_.lf*r + vy),2)+std::pow(vx,2)));
     const double dF_y_D     =  0.0;
-    const double dF_y_delta = (param.Bf*param.Cf*param.Df*std::cos(param.Cf*std::atan(param.Bf*alpha_f)))
-                                            /(1.+std::pow(param.Bf,2)*std::pow(alpha_f,2));
+    const double dF_y_delta = (param_.Bf*param_.Cf*param_.Df*std::cos(param_.Cf*std::atan(param_.Bf*alpha_f)))
+                                            /(1.+std::pow(param_.Bf,2)*std::pow(alpha_f,2));
 
     return {dF_y_vx,dF_y_vy,dF_y_r,dF_y_D,dF_y_delta,dF_x_vx,dF_x_vy,dF_x_r,dF_x_D,dF_x_delta};
 }
@@ -98,21 +98,21 @@ TireForcesDerivatives Model::getForceRearDerivatives(const State &x) const
     const double D  = x.D;
 
     //F_rx
-    const double dF_x_vx    = -param.Cm2*D;// - 2.0*param.Cr2*vx;
+    const double dF_x_vx    = -param_.Cm2*D;// - 2.0*param_.Cr2*vx;
     const double dF_x_vy    = 0.0;
     const double dF_x_r     = 0.0;
-    const double dF_x_D     = param.Cm1 - param.Cm2*vx;
+    const double dF_x_D     = param_.Cm1 - param_.Cm2*vx;
     const double dF_x_delta = 0.0;
     // F_ry
-    const double dF_y_vx    = ((param.Br*param.Cr*param.Dr*std::cos(param.Cr*std::atan(param.Br*alpha_r)))
-                                            /(1.+std::pow(param.Br,2)*std::pow(alpha_r,2)))*(-(param.lr*r - vy)
-                                            /(std::pow((-param.lr*r + vy),2)+std::pow(vx,2)));
-    const double dF_y_vy    = ((param.Br*param.Cr*param.Dr*std::cos(param.Cr*std::atan(param.Br*alpha_r)))
-                                            /(1.+std::pow(param.Br,2)*std::pow(alpha_r,2)))
-                                            *((-vx)/(std::pow((-param.lr*r + vy),2)+std::pow(vx,2)));
-    const double dF_y_r     = ((param.Br*param.Cr*param.Dr*std::cos(param.Cr*std::atan(param.Br*alpha_r)))
-                                            /(1.+std::pow(param.Br,2)*std::pow(alpha_r,2)))*((param.lr*vx)
-                                            /(std::pow((-param.lr*r + vy),2)+std::pow(vx,2)));
+    const double dF_y_vx    = ((param_.Br*param_.Cr*param_.Dr*std::cos(param_.Cr*std::atan(param_.Br*alpha_r)))
+                                            /(1.+std::pow(param_.Br,2)*std::pow(alpha_r,2)))*(-(param_.lr*r - vy)
+                                            /(std::pow((-param_.lr*r + vy),2)+std::pow(vx,2)));
+    const double dF_y_vy    = ((param_.Br*param_.Cr*param_.Dr*std::cos(param_.Cr*std::atan(param_.Br*alpha_r)))
+                                            /(1.+std::pow(param_.Br,2)*std::pow(alpha_r,2)))
+                                            *((-vx)/(std::pow((-param_.lr*r + vy),2)+std::pow(vx,2)));
+    const double dF_y_r     = ((param_.Br*param_.Cr*param_.Dr*std::cos(param_.Cr*std::atan(param_.Br*alpha_r)))
+                                            /(1.+std::pow(param_.Br,2)*std::pow(alpha_r,2)))*((param_.lr*vx)
+                                            /(std::pow((-param_.lr*r + vy),2)+std::pow(vx,2)));
     const double dF_y_D     = 0.0;
     const double dF_y_delta = 0.0;
 
@@ -121,7 +121,7 @@ TireForcesDerivatives Model::getForceRearDerivatives(const State &x) const
 
 FrictionForceDerivatives Model::getForceFrictionDerivatives(const State &x) const
 {
-    return {-2.0*param.Cr2*x.vx,0.0,0.0,0.0,0.0};
+    return {-2.0*param_.Cr2*x.vx,0.0,0.0,0.0,0.0};
 }
 
 StateVector Model::getF(const State &x,const Input &u) const
@@ -145,9 +145,9 @@ StateVector Model::getF(const State &x,const Input &u) const
     f(0) = vx*std::cos(phi) - vy*std::sin(phi);
     f(1) = vy*std::cos(phi) + vx*std::sin(phi);
     f(2) = r;
-    f(3) = 1.0/param.m*(tire_forces_rear.F_x - tire_forces_front.F_y*std::sin(delta) + param.m*vy*r);
-    f(4) = 1.0/param.m*(tire_forces_rear.F_y + tire_forces_front.F_y*std::cos(delta) - param.m*vx*r);
-    f(5) = 1.0/param.Iz*(tire_forces_front.F_y*param.lf*std::cos(delta) - tire_forces_rear.F_y*param.lr);
+    f(3) = 1.0/param_.m*(tire_forces_rear.F_x - tire_forces_front.F_y*std::sin(delta) + param_.m*vy*r);
+    f(4) = 1.0/param_.m*(tire_forces_rear.F_y + tire_forces_front.F_y*std::cos(delta) - param_.m*vx*r);
+    f(5) = 1.0/param_.Iz*(tire_forces_front.F_y*param_.lf*std::cos(delta) - tire_forces_rear.F_y*param_.lr);
     f(6) = vs;
     f(7) = dD;
     f(8) = dDelta;
@@ -194,24 +194,24 @@ LinModelMatrix Model::getModelJacobian(const State &x, const Input &u) const
     // f3 = r;
     const double df3_dr = 1.0;
 
-    // f4 = 1/param.m*(F_rx - F_fy*std::sin(delta) + param.m*v_y*r);
-    const double df4_dvx     = 1.0/param.m*(dF_rear.dF_x_vx - dF_front.dF_y_vx*std::sin(delta));
-    const double df4_dvy     = 1.0/param.m*(                - dF_front.dF_y_vy*std::sin(delta)    + param.m*r);
-    const double df4_dr      = 1.0/param.m*(                - dF_front.dF_y_r*std::sin(delta)     + param.m*vy);
-    const double df4_dD      = 1.0/param.m* dF_rear.dF_x_D;
-    const double df4_ddelta  = 1.0/param.m*(                - dF_front.dF_y_delta*std::sin(delta) - F_front.F_y*std::cos(delta));
+    // f4 = 1/param_.m*(F_rx - F_fy*std::sin(delta) + param_.m*v_y*r);
+    const double df4_dvx     = 1.0/param_.m*(dF_rear.dF_x_vx - dF_front.dF_y_vx*std::sin(delta));
+    const double df4_dvy     = 1.0/param_.m*(                - dF_front.dF_y_vy*std::sin(delta)    + param_.m*r);
+    const double df4_dr      = 1.0/param_.m*(                - dF_front.dF_y_r*std::sin(delta)     + param_.m*vy);
+    const double df4_dD      = 1.0/param_.m* dF_rear.dF_x_D;
+    const double df4_ddelta  = 1.0/param_.m*(                - dF_front.dF_y_delta*std::sin(delta) - F_front.F_y*std::cos(delta));
 
-    // f5 = 1/param.m*(F_ry + F_fy*std::cos(delta) - param.m*v_x*r);
-    const double df5_dvx     = 1.0/param.m*(dF_rear.dF_y_vx  + dF_front.dF_y_vx*std::cos(delta)    - param.m*r);
-    const double df5_dvy     = 1.0/param.m*(dF_rear.dF_y_vy  + dF_front.dF_y_vy*std::cos(delta));
-    const double df5_dr      = 1.0/param.m*(dF_rear.dF_y_r   + dF_front.dF_y_r*std::cos(delta)     - param.m*vx);
-    const double df5_ddelta  = 1.0/param.m*(                   dF_front.dF_y_delta*std::cos(delta) - F_front.F_y*std::sin(delta));
+    // f5 = 1/param_.m*(F_ry + F_fy*std::cos(delta) - param_.m*v_x*r);
+    const double df5_dvx     = 1.0/param_.m*(dF_rear.dF_y_vx  + dF_front.dF_y_vx*std::cos(delta)    - param_.m*r);
+    const double df5_dvy     = 1.0/param_.m*(dF_rear.dF_y_vy  + dF_front.dF_y_vy*std::cos(delta));
+    const double df5_dr      = 1.0/param_.m*(dF_rear.dF_y_r   + dF_front.dF_y_r*std::cos(delta)     - param_.m*vx);
+    const double df5_ddelta  = 1.0/param_.m*(                   dF_front.dF_y_delta*std::cos(delta) - F_front.F_y*std::sin(delta));
 
-    // f6 = 1/param.Iz*(F_fy*l_f*std::cos(delta)- F_ry*l_r)
-    const double df6_dvx     = 1.0/param.Iz*(dF_front.dF_y_vx*param.lf*std::cos(delta)    - dF_rear.dF_y_vx*param.lr);
-    const double df6_dvy     = 1.0/param.Iz*(dF_front.dF_y_vy*param.lf*std::cos(delta)    - dF_rear.dF_y_vy*param.lr);
-    const double df6_dr      = 1.0/param.Iz*(dF_front.dF_y_r*param.lf*std::cos(delta)     - dF_rear.dF_y_r*param.lr);
-    const double df6_ddelta  = 1.0/param.Iz*(dF_front.dF_y_delta*param.lf*std::cos(delta) - F_front.F_y*param.lf*std::sin(delta));
+    // f6 = 1/param_.Iz*(F_fy*l_f*std::cos(delta)- F_ry*l_r)
+    const double df6_dvx     = 1.0/param_.Iz*(dF_front.dF_y_vx*param_.lf*std::cos(delta)    - dF_rear.dF_y_vx*param_.lr);
+    const double df6_dvy     = 1.0/param_.Iz*(dF_front.dF_y_vy*param_.lf*std::cos(delta)    - dF_rear.dF_y_vy*param_.lr);
+    const double df6_dr      = 1.0/param_.Iz*(dF_front.dF_y_r*param_.lf*std::cos(delta)     - dF_rear.dF_y_r*param_.lr);
+    const double df6_ddelta  = 1.0/param_.Iz*(dF_front.dF_y_delta*param_.lf*std::cos(delta) - F_front.F_y*param_.lf*std::sin(delta));
 
     // Jacobians
     // Matrix A

--- a/C++/Model/model.h
+++ b/C++/Model/model.h
@@ -76,7 +76,13 @@ public:
     StateVector getF(const State &x,const Input &u) const;
 
     LinModelMatrix getLinModel(const State &x, const Input &u) const;
+
+    void setParam(const Param &params) { param_ = params; }
+    Param getParam(void) const { return param_; }
+
 private:
+    Param param_;
+
     LinModelMatrix getModelJacobian(const State &x, const Input &u) const;
     LinModelMatrix discretizeModel(const LinModelMatrix &lin_model_c) const;
 };

--- a/C++/Params/params.cpp
+++ b/C++/Params/params.cpp
@@ -16,11 +16,15 @@
 
 #include "params.h"
 namespace mpcc{
+    
 Param::Param(){
+}
+
+Param::Param(std::string file){
     /////////////////////////////////////////////////////
     // Loading Model and Constraint Parameters //////////
     /////////////////////////////////////////////////////
-    std::ifstream iModel("Params/model.json");
+    std::ifstream iModel(file);
     json jsonModel;
     iModel >> jsonModel;
     // Model Parameters
@@ -64,10 +68,13 @@ Param::Param(){
 
 CostParam::CostParam(){
 
+}
+
+CostParam::CostParam(std::string file){
     /////////////////////////////////////////////////////
     // Loading Cost Parameters //////////////////////////
     /////////////////////////////////////////////////////
-    std::ifstream iCost("Params/cost.json");
+    std::ifstream iCost(file);
     json jsonCost;
     iCost >> jsonCost;
 
@@ -100,11 +107,14 @@ CostParam::CostParam(){
 }
 
 BoundsParam::BoundsParam() {
+}
+
+BoundsParam::BoundsParam(std::string file) {
 
     /////////////////////////////////////////////////////
     // Loading Cost Parameters //////////////////////////
     /////////////////////////////////////////////////////
-    std::ifstream iBounds("Params/bounds.json");
+    std::ifstream iBounds(file);
     json jsonBounds;
     iBounds >> jsonBounds;
 
@@ -138,4 +148,5 @@ BoundsParam::BoundsParam() {
     upper_input_bounds.dDelta_u = jsonBounds["dDeltau"];
     upper_input_bounds.dVs_u = jsonBounds["dVsu"];
 }
+
 }

--- a/C++/Params/params.h
+++ b/C++/Params/params.h
@@ -64,6 +64,8 @@ public:
     double s_trust_region;
 
     Param();
+    Param(std::string file);
+
 };
 
 class CostParam{
@@ -96,6 +98,8 @@ public:
     double sc_lin_alpha;
 
     CostParam();
+    CostParam(std::string file);
+
 };
 
 class BoundsParam{
@@ -142,6 +146,8 @@ public:
     UpperInputBounds upper_input_bounds;
 
     BoundsParam();
+    BoundsParam(std::string file);
+
 };
 }
 #endif //MPCC_PARAMS_H

--- a/C++/Params/track.cpp
+++ b/C++/Params/track.cpp
@@ -16,26 +16,33 @@
 
 #include "track.h"
 namespace mpcc{
-TrackPos Track::getTrack()
+Track::Track(std::string file) 
 {
     /////////////////////////////////////////////////////
     // Loading Model and Constraint Parameters //////////
     /////////////////////////////////////////////////////
-    std::ifstream iTrack("Params/track.json");
+    std::ifstream iTrack(file);
     json jsonTrack;
     iTrack >> jsonTrack;
     // Model Parameters
-    std::vector<double> X = jsonTrack["X"];
-    std::vector<double> Y = jsonTrack["Y"];
+    std::vector<double> x = jsonTrack["X"];
+    X = Eigen::Map<Eigen::VectorXd>(x.data(), x.size());
+    std::vector<double> y = jsonTrack["Y"];
+    Y = Eigen::Map<Eigen::VectorXd>(y.data(), y.size());
+    
+    std::vector<double> x_inner = jsonTrack["X_i"];
+    X_inner = Eigen::Map<Eigen::VectorXd>(x_inner.data(), x_inner.size());
+    std::vector<double> y_inner = jsonTrack["Y_i"];
+    Y_inner = Eigen::Map<Eigen::VectorXd>(y_inner.data(), y_inner.size());
 
-    std::vector<double> X_inner = jsonTrack["X_i"];
-    std::vector<double> Y_inner = jsonTrack["Y_i"];
+    std::vector<double> x_outer = jsonTrack["X_o"];
+    X_outer = Eigen::Map<Eigen::VectorXd>(x_outer.data(), x_outer.size());
+    std::vector<double> y_outer = jsonTrack["Y_o"];
+    Y_outer = Eigen::Map<Eigen::VectorXd>(y_outer.data(), y_outer.size());
+}
 
-    std::vector<double> X_outer = jsonTrack["X_o"];
-    std::vector<double> Y_outer = jsonTrack["Y_o"];
-//    TrackPos track_xy;
-//    track_xy.X = Eigen::Map<Eigen::VectorXd>(X.data(), X.size());
-//    track_xy.Y = Eigen::Map<Eigen::VectorXd>(Y.data(), Y.size());
+TrackPos Track::getTrack()
+{
     return {Eigen::Map<Eigen::VectorXd>(X.data(), X.size()), Eigen::Map<Eigen::VectorXd>(Y.data(), Y.size()),
             Eigen::Map<Eigen::VectorXd>(X_inner.data(), X_inner.size()), Eigen::Map<Eigen::VectorXd>(Y_inner.data(), Y_inner.size()),
             Eigen::Map<Eigen::VectorXd>(X_outer.data(), X_outer.size()), Eigen::Map<Eigen::VectorXd>(Y_outer.data(), Y_outer.size())};

--- a/C++/Params/track.h
+++ b/C++/Params/track.h
@@ -41,7 +41,18 @@ struct TrackPos {
 
 class Track {
 public:
+    Track(std::string file);
     TrackPos getTrack();
+
+private:
+    Eigen::VectorXd X;
+    Eigen::VectorXd Y;
+
+    Eigen::VectorXd X_inner;
+    Eigen::VectorXd Y_inner;
+
+    Eigen::VectorXd X_outer;
+    Eigen::VectorXd Y_outer;
 };
 };
 

--- a/C++/Plotting/plotting.cpp
+++ b/C++/Plotting/plotting.cpp
@@ -16,6 +16,10 @@
 
 #include "plotting.h"
 namespace mpcc{
+
+Plotting::Plotting(Model model) {
+    model_ = model;
+}
 void Plotting::plotRun(const std::list<MPCReturn> &log, const TrackPos &track_xy) const
 {
 
@@ -79,8 +83,8 @@ void Plotting::plotRun(const std::list<MPCReturn> &log, const TrackPos &track_xy
     std::vector<double> plot_eps_y;
     for(double t = 0; t<2*M_PI;t+=0.1)
     {
-        plot_eps_x.push_back(cos(t)*param.Dr*param.e_eps);
-        plot_eps_y.push_back(sin(t)*param.Dr*1./param.e_long*param.e_eps);
+        plot_eps_x.push_back(cos(t)*model_.getParam().Dr*model_.getParam().e_eps);
+        plot_eps_y.push_back(sin(t)*model_.getParam().Dr*1./model_.getParam().e_long*model_.getParam().e_eps);
     }
 
     plt::figure(1);
@@ -192,10 +196,10 @@ void Plotting::plotBox(const State &x0) const
 {
     std::vector<double> corner_x;
     std::vector<double> corner_y;
-    double body_xl = std::cos(x0.phi)*param.car_l;
-    double body_xw = std::sin(x0.phi)*param.car_w;
-    double body_yl = std::sin(x0.phi)*param.car_l;
-    double body_yw = -std::cos(x0.phi)*param.car_w;
+    double body_xl = std::cos(x0.phi)*model_.getParam().car_l;
+    double body_xw = std::sin(x0.phi)*model_.getParam().car_w;
+    double body_yl = std::sin(x0.phi)*model_.getParam().car_l;
+    double body_yw = -std::cos(x0.phi)*model_.getParam().car_w;
 
     corner_x.push_back(x0.X + body_xl + body_xw);
     corner_x.push_back(x0.X + body_xl - body_xw);

--- a/C++/Plotting/plotting.h
+++ b/C++/Plotting/plotting.h
@@ -33,6 +33,8 @@ public:
     void plotRun(const std::list<MPCReturn> &log, const TrackPos &track_xy) const;
     void plotSim(const std::list<MPCReturn> &log, const TrackPos &track_xy) const;
 
+    Plotting(Model model);
+
 private:
     void plotBox(const State &x0) const;
 

--- a/C++/Spline/arc_length_spline.cpp
+++ b/C++/Spline/arc_length_spline.cpp
@@ -267,7 +267,7 @@ double ArcLengthSpline::porjectOnSpline(const State &x) const
     double s_opt = s_guess;
     double dist = (pos-pos_path).norm();
 
-    if (dist >= param.max_dist_proj)
+    if (dist >= param_.max_dist_proj)
     {
         std::cout << "dist too large" << std::endl;
         Eigen::ArrayXd diff_x_all = path_data_.X.array() - pos(0);

--- a/C++/Spline/arc_length_spline.h
+++ b/C++/Spline/arc_length_spline.h
@@ -41,6 +41,7 @@ private:
 //    PathData pathDataFinal; // final data
     CubicSpline spline_x_;
     CubicSpline spline_y_;
+    Param param_;
 
     void setData(const Eigen::VectorXd &X_in,const Eigen::VectorXd &Y_in);
     void setRegularData(const Eigen::VectorXd &X_in,const Eigen::VectorXd &Y_in,const Eigen::VectorXd &s_in);
@@ -57,6 +58,8 @@ public:
     Eigen::Vector2d getSecondDerivative(double) const;
     double getLength() const;
     double porjectOnSpline(const State &x) const;
+    void setParam(const Param &param) { param_ = param; };
+
 };
 }
 #endif //MPCC_ARC_LENGTH_SPLINE_H

--- a/C++/Tests/constratins_test.cpp
+++ b/C++/Tests/constratins_test.cpp
@@ -68,11 +68,12 @@ void genRoundTrack(ArcLengthSpline &track){
 
 }
 
-int testAlphaConstraint(){
-    Constraints constraints;
-    Model model;
-    ArcLengthSpline track;
+int testAlphaConstraint(const Param &param, const Model &model){
+    Constraints constraints = Constraints(param);
 
+    ArcLengthSpline track;
+    track.setParam(param);
+    
     double alpha_f;
     genRoundTrack(track);
 
@@ -99,14 +100,14 @@ int testAlphaConstraint(){
     std::cout << "true alpha " << alpha_f  << std::endl;
     std::cout << constraints_0.dl(2) << "<=" << constraints_0.C.row(2)*xk1_vec <<  "<=" << constraints_0.du(2) << std::endl;
 
-    if ((constraints_0.dl(2)<= constraints_0.C.row(2)*xk1_vec && constraints_0.C.row(2)*xk1_vec  <= constraints_0.du(2)) ^ (-param.max_alpha <= alpha_f && alpha_f  <= param.max_alpha)){
+    if ((constraints_0.dl(2)<= constraints_0.C.row(2)*xk1_vec && constraints_0.C.row(2)*xk1_vec  <= constraints_0.du(2)) ^ (-model.getParam().max_alpha <= alpha_f && alpha_f  <= model.getParam().max_alpha)){
         return  0;
     }
 
     ConstrainsMatrix constraints_1 = constraints.getConstraints(track,xk1,uk1);
     std::cout << constraints_1.dl(2) << "<=" << constraints_1.C.row(2)*xk1_vec <<  "<=" << constraints_1.du(2) << std::endl;
 
-    if ((constraints_1.dl(2)<= constraints_1.C.row(2)*xk1_vec && constraints_1.C.row(2)*xk1_vec  <= constraints_1.du(2)) ^ (-param.max_alpha <= alpha_f && alpha_f  <= param.max_alpha)){
+    if ((constraints_1.dl(2)<= constraints_1.C.row(2)*xk1_vec && constraints_1.C.row(2)*xk1_vec  <= constraints_1.du(2)) ^ (-model.getParam().max_alpha <= alpha_f && alpha_f  <= model.getParam().max_alpha)){
         return  0;
     }
 
@@ -118,7 +119,7 @@ int testAlphaConstraint(){
     std::cout << "true alpha " << alpha_f  << std::endl;
     std::cout << constraints_2.dl(2) << "<=" << constraints_2.C.row(2)*xk2_vec <<  "<=" << constraints_2.du(2) << std::endl;
 
-    if ((constraints_2.dl(2)<= constraints_2.C.row(2)*xk2_vec && constraints_2.C.row(2)*xk2_vec  <= constraints_2.du(2)) ^ (-param.max_alpha <= alpha_f && alpha_f  <= param.max_alpha)){
+    if ((constraints_2.dl(2)<= constraints_2.C.row(2)*xk2_vec && constraints_2.C.row(2)*xk2_vec  <= constraints_2.du(2)) ^ (-model.getParam().max_alpha <= alpha_f && alpha_f  <= model.getParam().max_alpha)){
         return  0;
     }
 
@@ -127,9 +128,8 @@ int testAlphaConstraint(){
 }
 
 
-int testTireForceConstraint() {
-    Constraints constraints;
-    Model model;
+int testTireForceConstraint(const Param &param, const Model &model) {
+    Constraints constraints = Constraints(param);
     ArcLengthSpline track;
 
 
@@ -157,8 +157,8 @@ int testTireForceConstraint() {
 
     TireForces f_rear = model.getForceRear(xk1);
 
-    tireForce = std::sqrt(std::pow(param.e_long*f_rear.F_x,2) + std::pow(f_rear.F_y,2));
-    maxForce = param.e_eps*param.Dr;
+    tireForce = std::sqrt(std::pow(model.getParam().e_long*f_rear.F_x,2) + std::pow(f_rear.F_y,2));
+    maxForce = model.getParam().e_eps*model.getParam().Dr;
 
     ConstrainsMatrix constraints_mat = constraints.getConstraints(track,xk2,uk2);
 
@@ -170,8 +170,8 @@ int testTireForceConstraint() {
 }
 
 
-int testTrackConstraint() {
-    Constraints constraints;
+int testTrackConstraint(const Param &param) {
+    Constraints constraints = Constraints(param);
     ArcLengthSpline track;
 
     genRoundTrack(track);

--- a/C++/Tests/constratins_test.h
+++ b/C++/Tests/constratins_test.h
@@ -22,8 +22,8 @@
 #include "Constraints/constraints.h"
 namespace mpcc{
 void genRoundTrack(ArcLengthSpline& track);
-int testAlphaConstraint();
-int testTireForceConstraint();
-int testTrackConstraint();
+int testAlphaConstraint(const Param &param, const Model &model);
+int testTireForceConstraint(const Param &param, const Model &model);
+int testTrackConstraint(const Param &param);
 }
 #endif //MPCC_CONSTRATINS_TEST_H

--- a/C++/Tests/cost_test.cpp
+++ b/C++/Tests/cost_test.cpp
@@ -16,8 +16,9 @@
 
 #include "cost_test.h"
 namespace mpcc{
-int testCost(){
-    Cost cost;
+int testCost(const CostParam &cost_param){
+    Cost cost = Cost(cost_param);
+    //cost.setCosts(cost_param);
     ArcLengthSpline track;
     genRoundTrack(track);
 

--- a/C++/Tests/cost_test.h
+++ b/C++/Tests/cost_test.h
@@ -20,7 +20,7 @@
 #include "Cost/cost.h"
 #include "constratins_test.h"
 namespace mpcc{
-int testCost();
+int testCost(const CostParam &cost_param);
 }
 
 #endif //MPCC_COST_TEST_H

--- a/C++/Tests/model_integrator_test.cpp
+++ b/C++/Tests/model_integrator_test.cpp
@@ -16,11 +16,12 @@
 
 #include "model_integrator_test.h"
 namespace mpcc{
-int testIntegrator(){
+int testIntegrator(const Integrator &integrator){
 
     // test integrator by comparing Euler forward to RK4
     // 3 differnet test points, hand picked, going straight and random
-    Integrator integrator;
+
+    //Integrator integrator;
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Hand picked x and u
     StateVector error1;
@@ -58,11 +59,12 @@ int testIntegrator(){
 
 }
 
-int testLinModel(){
+int testLinModel(const Integrator &integrator){
     // test Liniear model by comparing it to RK4
     // 3 differnet test cases, hand picked, going straight and test how good linear model generalizes
-    Integrator integrator;
-    Model model;
+
+    const Model model = integrator.getModel();
+    
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Hand picked x and u
     StateVector error1;

--- a/C++/Tests/model_integrator_test.h
+++ b/C++/Tests/model_integrator_test.h
@@ -20,7 +20,7 @@
 #include "Model/model.h"
 #include "Model/integrator.h"
 namespace mpcc{
-int testIntegrator();
-int testLinModel();
+int testIntegrator(const Integrator &integrator);
+int testLinModel(const Integrator &integrator);
 }
 #endif //MPCC_MODEL_INTEGRATOR_TEST_H

--- a/C++/config.h
+++ b/C++/config.h
@@ -42,9 +42,6 @@ static constexpr double TS = 0.02;
 static constexpr double INF = 1E5;
 static constexpr int N_SPLINE = 1000;
 
-static const Param param;
-static const CostParam cost_param;
-static const BoundsParam bounds_param;
 
 struct StateInputIndex{
     int X = 0;

--- a/C++/main.cpp
+++ b/C++/main.cpp
@@ -31,31 +31,38 @@ int main() {
 
     using namespace mpcc;
 
-
-//    std::cout << testSpline() << std::endl;
-//    std::cout << testArcLengthSpline() << std::endl;
-//
-//    std::cout << testIntegrator() << std::endl;
-//    std::cout << testLinModel() << std::endl;
-//
-//    std::cout << testAlphaConstraint() << std::endl;
-//    std::cout << testTireForceConstraint() << std::endl;
-//    std::cout << testTrackConstraint() << std::endl;
-//
-//    std::cout << testCost() << std::endl;
+    Param param = Param("Params/model.json");
+    CostParam cost_param = CostParam("Params/cost.json");
+    BoundsParam bounds_param = BoundsParam("Params/bounds.json");
+    Track track = Track("Params/track.json");
 
     std::ifstream iConfig("Params/config.json");
     json jsonConfig;
     iConfig >> jsonConfig;
 
-    Integrator integrator;
-    Plotting plotter;
+    Integrator integrator = Integrator(param);
+    Model model = integrator.getModel();
 
-    Track track;
+//    std::cout << testSpline() << std::endl;
+//    std::cout << testArcLengthSpline() << std::endl;
+//
+//    std::cout << testIntegrator(integrator) << std::endl;
+//    std::cout << testLinModel(integrator) << std::endl;
+//
+//    std::cout << testAlphaConstraint(param, model) << std::endl;
+//    std::cout << testTireForceConstraint(param, model) << std::endl;
+//    std::cout << testTrackConstraint(param) << std::endl;
+//
+//    std::cout << testCost(cost_param) << std::endl;
+//    return 0;
+
+
+    Plotting plotter = Plotting(model);
+
     TrackPos track_xy = track.getTrack();
 
     std::list<MPCReturn> log;
-    MPC mpc(jsonConfig["n_sqp"],jsonConfig["n_reset"],jsonConfig["sqp_mixing"]);
+    MPC mpc(jsonConfig["n_sqp"],jsonConfig["n_reset"],jsonConfig["sqp_mixing"], param, cost_param, bounds_param);
     mpc.setTrack(track_xy.X,track_xy.Y);
     State x0 = {track_xy.X(0),track_xy.Y(0),-1*M_PI/4.0,0.05,0,0,0,1.0,0,1.0};
     for(int i=0;i<jsonConfig["n_sim"];i++)


### PR DESCRIPTION
Dear Alex, 

I have changed the method how the parameters (JSON files) are loaded, because the paths are related defined in your implementation. 

I have deleted param, cost_param and bounds_param in config.h. The parameters are now loaded at the beginning in the main. Which makes it possible to export your implementation as a library and use it e.g. in a ROS node, there would be issues with the relative paths for the JSONs. 

Maybe there is a simpler solution. Do you have a different suggestion? 

The tests provide the same results.  

My next pull request is going to include two ROS nodes which share the state and the input:  
- simulator (integrator)  
- MPCC 

The movement of the vehicle and the racetrack are visualized in RVIZ.  

Best, 
Markus 