### PR TITLE
[C++] Fix install.sh

### DIFF
--- a/C++/install.sh
+++ b/C++/install.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 ## Copyright 2019 Alexander Liniger
 
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,9 +14,9 @@
 ## limitations under the License.
 ###########################################################################
 ###########################################################################
-## install dependincies
+## Install dependencies
+set -e
 
-#!/bin/bash
 ## clone blasfeo
 repository_blasfeo="https://github.com/giaf/blasfeo.git"
 localFolder_blasfeo="External/blasfeo"
@@ -42,7 +43,7 @@ cd External/blasfeo
 mkdir -p build
 mkdir -p lib
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=../lib
+cmake .. -DCMAKE_INSTALL_PREFIX=$(realpath ../lib)
 make
 make install
 
@@ -50,6 +51,6 @@ cd ../../hpipm
 mkdir -p build
 mkdir -p lib
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=../lib -DBLASFEO_PATH=../../blasfeo/lib
+cmake .. -DCMAKE_INSTALL_PREFIX=$(realpath ../lib) -DBLASFEO_PATH=$(realpath ../../blasfeo/lib)
 make
 make install


### PR DESCRIPTION
This PR fixes some issues in `install.sh` as it does not work out of the box (tested on Ubuntu 20.04). Namely those fixes are:

- use `realpath` to avoid passing relative paths to cmake
- Add `set -e` line to stop the script on first error
- Move shebang to first line of the file so it gets recognized
- Align used interpreter with file ending (sh)
- Correct spelling
- Add trailing newline

Solves #39.