### PR TITLE
[C++] Enable use of Python3

### DIFF
--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -36,8 +36,8 @@ add_executable(MPCC
         Plotting/plotting.cpp
         Plotting/plotting.h)
 
-find_package(PythonLibs 2.7)
-target_include_directories(MPCC PRIVATE ${PYTHON_INCLUDE_DIRS})
-target_link_libraries(MPCC ${PYTHON_LIBRARIES})
+find_package(Python COMPONENTS Development)
+target_include_directories(MPCC PRIVATE ${Python_INCLUDE_DIRS})
+target_link_libraries(MPCC ${Python_LIBRARIES})
 
 target_link_libraries(MPCC ${CMAKE_SOURCE_DIR}/External/hpipm/lib/lib/libhpipm.a ${CMAKE_SOURCE_DIR}/External/blasfeo/lib/lib/libblasfeo.a m)


### PR DESCRIPTION
This PR changes `CMakeLists.txt` to enable the use of Python 3, which is required as Python 2 is no longer supported.