### PR TITLE
[C++] Add .gitignore

### DIFF
--- a/C++/.gitignore
+++ b/C++/.gitignore
@@ -1,0 +1,9 @@
+# Project specific excludes
+/External/
+/MPCC
+
+# CMake
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake


### PR DESCRIPTION
Adds a `.gitignore` file for the folder of the C++ implementation. It excludes temporary CMake files as well as the `External` folder and the resulting binary.